### PR TITLE
Limit width of videos to 100% of screen width

### DIFF
--- a/_site/theme.css
+++ b/_site/theme.css
@@ -93,6 +93,7 @@ d-article h3 {
 
 video {
 	padding-top: 10px;
+	max-width: 100%;
 }
 
 .highlight {


### PR DESCRIPTION
I haven't tested this across the whole site, but locally editing page CSS this way fixes the issue on [the Gradient Descent page](https://maximilianrohde.com/posts/2021-01-16-graddescpt1/) where I found it

Resolves #1 